### PR TITLE
fix date_format parameter for DateCol

### DIFF
--- a/flask_table/columns.py
+++ b/flask_table/columns.py
@@ -135,9 +135,9 @@ class DateCol(Col):
     output empty.
 
     """
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, date_format='short', **kwargs):
         Col.__init__(self, name, **kwargs)
-        self.date_format = kwargs.get('date_format', 'short')
+        self.date_format = date_format
 
     def td_format(self, content):
         if content:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -338,6 +338,15 @@ class DateTest(TableTest):
         items = [Item(date=date(2014, 1, 1)), Item(date=None)]
         self.assert_html_equivalent_from_file('date_test', 'test_one', items)
 
+class DateTestFormat(TableTest):
+    def setUp(self):
+        class MyTable(Table):
+            date = DateCol('Date Heading', date_format="YYYY-MM-dd")
+        self.table_cls = MyTable
+
+    def test_one(self):
+        items = [Item(date=date(2014, 2, 1)), Item(date=None)]
+        self.assert_html_equivalent_from_file('date_test_format', 'test_one', items)
 
 class DatetimeTest(TableTest):
     def setUp(self):

--- a/tests/html/date_test_format/test_one.html
+++ b/tests/html/date_test_format/test_one.html
@@ -1,0 +1,10 @@
+<table>
+  <thead>
+    <tr><th>Date Heading</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>2014-02-01</td></tr>
+    <tr><td></td></tr>
+  </tbody>
+</table>
+


### PR DESCRIPTION
got this error:

```
Traceback (most recent call last):
  File "[...]/flask_table/tests/__init__.py", line 333, in setUp
    class MyTable(Table):
  File "[...]/flask_table/tests/__init__.py", line 334, in MyTable
    date = DateCol('Date Heading', date_format='D/M/YY')
  File "[...]/flask_table/flask_table/columns.py", line 142, in __init__
    Col.__init__(self, name, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'date_format'
```

should be fixed now
