### PR TITLE
Add config for read-the-docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: Flask Table
+pages:
+- Flask Table: index.md


### PR DESCRIPTION
Just links to the main README.md so that the documentation isn't duplicated.