### PR TITLE
Add facility to add an id tag to a table

### DIFF
--- a/flask_table/table.py
+++ b/flask_table/table.py
@@ -55,7 +55,8 @@ class Table(with_metaclass(TableMeta)):
     no_items = 'No Items'
 
     def __init__(self, items, classes=None, thead_classes=None,
-                 sort_by=None, sort_reverse=False, no_items=None):
+                 sort_by=None, sort_reverse=False, no_items=None,
+                 table_id=None):
         self.items = items
         self.sort_by = sort_by
         self.sort_reverse = sort_reverse
@@ -65,12 +66,15 @@ class Table(with_metaclass(TableMeta)):
             self.thead_classes = thead_classes
         if no_items is not None:
             self.no_items = no_items
+        self.table_id = table_id
 
     def classes_html_attr(self):
-        if not self.classes:
-            return ''
-        else:
-            return ' class="{}"'.format(' '.join(self.classes))
+        s = ''
+        if self.table_id:
+            s += ' id="{}"'.format(self.table_id)
+        if self.classes:
+            s += ' class="{}"'.format(' '.join(self.classes))
+        return s
 
     def thead_classes_html_attr(self):
         if not self.thead_classes:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -60,7 +60,8 @@ class TableTest(unittest.TestCase):
             return f.read()
 
     def assert_html_equivalent_from_file(self, d, name, items=[], **kwargs):
-        tab = kwargs.get('tab', self.table_cls(items))
+        table_id = kwargs.get('table_id', None)
+        tab = kwargs.get('tab', self.table_cls(items, table_id=table_id))
         if kwargs.get('print_html'):
             print(tab.__html__())
         html = self.get_html(d, name)
@@ -90,6 +91,18 @@ def test_app():
 class FlaskTableTest(flask_testing.TestCase, TableTest):
     def create_app(self):
         return test_app()
+
+
+class TableIDTest(TableTest):
+    def setUp(self):
+        class MyTable(Table):
+            name = Col('Name Heading')
+        self.table_cls = MyTable
+
+    def test_one(self):
+        items = [Item(name='one')]
+        self.assert_html_equivalent_from_file(
+            'tableid_test', 'test_one', items, table_id='Test table ID')
 
 
 class ColTest(TableTest):

--- a/tests/html/tableid_test/test_one.html
+++ b/tests/html/tableid_test/test_one.html
@@ -1,0 +1,6 @@
+<table id="Test table ID">
+<thead><tr><th>Name Heading</th></tr></thead>
+<tbody>
+<tr><td>one</td></tr>
+</tbody>
+</table>


### PR DESCRIPTION
It's often necessary to have an id field in a table for use with javascript etc. This adds that facility via the table_id keyword argument added to the Table object initializer. I've also added a test for this.