### PR TITLE
Add Markup Safe Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Extra things:
 
 * But most importantly, Col is easy to subclass.
 
+Markup Safe Option
+------------------
+By default, table content is escaped to keep Markup Safe, but if you don't want it to be escaped and want to keep as it is. Setting `convert` of you `__html__()` function like `table.__html__(convert=False)`.
+
 Included Col Types
 ==================
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -20,14 +20,14 @@ class ItemTable(Table):
 
 
 def main():
-    items = [Item('Name1', 'Description1'),
+    items = [Item('Name1', '<'),
              Item('Name2', 'Description2'),
              Item('Name3', 'Description3')]
 
     table = ItemTable(items)
 
     # or {{ table }} in jinja
-    print(table.__html__())
+    print(table.__html__(convert=False))
 
     """Outputs:
 

--- a/flask_table/columns.py
+++ b/flask_table/columns.py
@@ -108,7 +108,7 @@ class Col(object):
         data that attr_list gets from the item, but need to adjust how
         it is represented.
 
-        Note that the output of this function is escaped.
+        Using convert to choose the output if escaped or not.
 
         """
         if convert:
@@ -138,9 +138,10 @@ class OptCol(Col):
         else:
             return content
 
-    def td_format(self, content):
-        return self.choices.get(
+    def td_format(self, content, convert):
+        data = self.choices.get(
             self.coerce_content(content), self.default_value)
+        return super(OptCol, self).td_format(data, convert)
 
 
 class BoolCol(OptCol):
@@ -165,9 +166,10 @@ class DateCol(Col):
         super(DateCol, self).__init__(name, **kwargs)
         self.date_format = date_format
 
-    def td_format(self, content):
+    def td_format(self, content, convert):
         if content:
-            return format_date(content, self.date_format)
+            return super(DateCol, self).td_format(
+                format_date(content, self.date_format), convert)
         else:
             return ''
 
@@ -181,9 +183,10 @@ class DatetimeCol(Col):
         super(DatetimeCol, self).__init__(name, **kwargs)
         self.datetime_format = datetime_format
 
-    def td_format(self, content):
+    def td_format(self, content, convert):
         if content:
-            return format_datetime(content, self.datetime_format)
+            return super(DatetimeCol, self).td_format(
+                format_datetime(content, self.datetime_format), convert)
         else:
             return ''
 
@@ -249,12 +252,14 @@ class ButtonCol(LinkCol):
 
     """
 
-    def td_contents(self, item, attr_list):
+    def td_contents(self, item, attr_list, convert):
+        content = Markup.escape(self.text(item, attr_list))\
+            if convert else self.text(item, attr_list)
         return '<form method="post" action="{url}">'\
             '<button type="submit">{text}</button>'\
             '</form>'.format(
                 url=self.url(item),
-                text=Markup.escape(self.text(item, attr_list)))
+                text=content)
 
 
 class NestedTableCol(Col):
@@ -280,6 +285,6 @@ class NestedTableCol(Col):
         super(NestedTableCol, self).__init__(name, **kwargs)
         self.table_class = table_class
 
-    def td_format(self, content):
-        t = self.table_class(content).__html__()
+    def td_format(self, content, convert):
+        t = self.table_class(content).__html__(convert)
         return t

--- a/flask_table/columns.py
+++ b/flask_table/columns.py
@@ -80,11 +80,11 @@ class Col(object):
         else:
             return out
 
-    def td(self, item, attr):
+    def td(self, item, attr, convert):
         return '<td>{}</td>'.format(
-            self.td_contents(item, self.get_attr_list(attr)))
+            self.td_contents(item, self.get_attr_list(attr), convert))
 
-    def td_contents(self, item, attr_list):
+    def td_contents(self, item, attr_list, convert):
         """Given an item and an attr, return the contents of the
         <td>.
 
@@ -96,9 +96,9 @@ class Col(object):
         Note that the output of this function is NOT escaped.
 
         """
-        return self.td_format(self.from_attr_list(item, attr_list))
+        return self.td_format(self.from_attr_list(item, attr_list), convert)
 
-    def td_format(self, content):
+    def td_format(self, content, convert):
         """Given just the value extracted from the item, return what should
         appear within the td.
 
@@ -111,7 +111,10 @@ class Col(object):
         Note that the output of this function is escaped.
 
         """
-        return Markup.escape(content)
+        if convert:
+            return Markup.escape(content)
+        else:
+            return content
 
 
 class OptCol(Col):
@@ -228,10 +231,10 @@ class LinkCol(Col):
     def url(self, item):
         return url_for(self.endpoint, **self.url_kwargs(item))
 
-    def td_contents(self, item, attr_list):
+    def td_contents(self, item, attr_list, convert):
         return '<a href="{url}">{text}</a>'.format(
             url=self.url(item),
-            text=self.td_format(self.text(item, attr_list)))
+            text=self.td_format(self.text(item, attr_list), convert))
 
 
 class ButtonCol(LinkCol):

--- a/flask_table/table.py
+++ b/flask_table/table.py
@@ -85,8 +85,8 @@ class Table(with_metaclass(TableMeta)):
         else:
             return ' class="{}"'.format(' '.join(self.thead_classes))
 
-    def __html__(self):
-        tbody = self.tbody()
+    def __html__(self, convert=True):
+        tbody = self.tbody(convert)
         if tbody:
             return '<table{attrs}>\n{thead}\n{tbody}\n</table>'.format(
                 attrs=self.classes_html_attr(),
@@ -102,8 +102,8 @@ class Table(with_metaclass(TableMeta)):
                 (self.th(col_key, col) for col_key, col in self._cols.items()
                  if col.show)))
 
-    def tbody(self):
-        out = [self.tr(item) for item in self.items]
+    def tbody(self, convert):
+        out = [self.tr(item, convert) for item in self.items]
         if out:
             return '<tbody>\n{}\n</tbody>'.format('\n'.join(out))
         else:
@@ -118,9 +118,9 @@ class Table(with_metaclass(TableMeta)):
 
         return '<tr>{}</tr>'
 
-    def tr(self, item):
+    def tr(self, item, convert):
         return self.tr_format(item).format(
-            ''.join(c.td(item, attr) for attr, c in self._cols.items()
+            ''.join(c.td(item, attr, convert) for attr, c in self._cols.items()
                     if c.show))
 
     def th_contents(self, col_key, col):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -300,6 +300,7 @@ class ColCallableTest(ColTest):
         self.assert_html_equivalent_from_file(
             'col_test', 'test_markupsafe', items, convert=False)
 
+
 class AttrListTest(TableTest):
     def setUp(self):
         class MyTable(Table):
@@ -797,7 +798,8 @@ class NestedColTest(TableTest):
     def test_markupsafe(self):
         items = [Item(a='row1', nest=[Item(b='r1asc1', c='r1asc2'),
                                       Item(b='r1bsc1', c='r1bsc2')]),
-                 Item(a='row2', nest=[Item(b='<b>r2asc1</b>', c='<b>r2asc2</b>'),
-                                      Item(b='<b>r2bsc1</b>', c='<b>r2bsc2</b>')])]
+                 Item(a='row2',
+                      nest=[Item(b='<b>r2asc1</b>', c='<b>r2asc2</b>'),
+                            Item(b='<b>r2bsc1</b>', c='<b>r2bsc2</b>')])]
         self.assert_html_equivalent_from_file(
             'nestedcol_test', 'test_markupsafe', items, convert=False)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,7 +32,7 @@ class TableTest(unittest.TestCase):
     def assert_in(self, x, y):
         if x not in y:
             raise AssertionError(
-                '{x} is not in {}, but should be.'.format(x=x, y=y))
+                '{x} is not in {y}, but should be.'.format(x=x, y=y))
 
     def assert_in_html(self, x, y):
         return self.assert_in(x, y.__html__())
@@ -45,9 +45,9 @@ class TableTest(unittest.TestCase):
     def assert_not_in_html(self, x, y):
         return self.assert_not_in(x, y.__html__())
 
-    def assert_html_equivalent(self, test_tab, reference):
+    def assert_html_equivalent(self, test_tab, reference, convert):
         self.assertEqual(
-            html_reduce(test_tab.__html__()),
+            html_reduce(test_tab.__html__(convert)),
             html_reduce(reference))
 
     @classmethod
@@ -58,15 +58,14 @@ class TableTest(unittest.TestCase):
         with io.open(path, encoding="utf8") as f:
             return f.read()
 
-    def assert_html_equivalent_from_file(self, d, name, items=[], **kwargs):
+    def assert_html_equivalent_from_file(
+            self, d, name, items=[], convert=True, **kwargs):
         table_id = kwargs.get('table_id', None)
         border = kwargs.get('border', False)
         tab = kwargs.get('tab', self.table_cls(
             items, table_id=table_id, border=border))
-        if kwargs.get('print_html'):
-            print(tab.__html__())
         html = self.get_html(d, name)
-        self.assert_html_equivalent(tab, html)
+        self.assert_html_equivalent(tab, html, convert)
 
 
 def test_app():
@@ -154,6 +153,11 @@ class ColTest(TableTest):
         items = [Item(name='äöüß')]
         self.assert_html_equivalent_from_file(
             'col_test', 'test_encoding', items)
+
+    def test_markupsafe(self):
+        items = [Item(name='<input id="0718" name="Panda" type="text">')]
+        self.assert_html_equivalent_from_file(
+            'col_test', 'test_markupsafe', items, convert=False)
 
 
 class HideTest(ColTest):
@@ -291,6 +295,10 @@ class ColCallableTest(ColTest):
         self.assert_html_equivalent_from_file(
             'col_test', 'test_encoding', items)
 
+    def test_markupsafe(self):
+        items = [FuncItem(name='<input id="0718" name="Panda" type="text">')]
+        self.assert_html_equivalent_from_file(
+            'col_test', 'test_markupsafe', items, convert=False)
 
 class AttrListTest(TableTest):
     def setUp(self):
@@ -785,3 +793,11 @@ class NestedColTest(TableTest):
                                       Item(b='r2bsc1', c='r2bsc2')])]
         self.assert_html_equivalent_from_file(
             'nestedcol_test', 'test_one', items)
+
+    def test_markupsafe(self):
+        items = [Item(a='row1', nest=[Item(b='r1asc1', c='r1asc2'),
+                                      Item(b='r1bsc1', c='r1bsc2')]),
+                 Item(a='row2', nest=[Item(b='<b>r2asc1</b>', c='<b>r2asc2</b>'),
+                                      Item(b='<b>r2bsc1</b>', c='<b>r2bsc2</b>')])]
+        self.assert_html_equivalent_from_file(
+            'nestedcol_test', 'test_markupsafe', items, convert=False)

--- a/tests/html/col_test/test_markupsafe.html
+++ b/tests/html/col_test/test_markupsafe.html
@@ -1,0 +1,10 @@
+<table>
+  <thead>
+    <tr><th>Name Heading</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><input id="0718" name="Panda" type="text"></td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/html/nestedcol_test/test_markupsafe.html
+++ b/tests/html/nestedcol_test/test_markupsafe.html
@@ -1,0 +1,19 @@
+<table>
+<thead><tr><th>a</th><th>Nested column</th></tr></thead>
+<tbody>
+<tr><td>row1</td><td><table>
+<thead><tr><th>b</th><th>c</th></tr></thead>
+<tbody>
+<tr><td>r1asc1</td><td>r1asc2</td></tr>
+<tr><td>r1bsc1</td><td>r1bsc2</td></tr>
+</tbody>
+</table></td></tr>
+<tr><td>row2</td><td><table>
+<thead><tr><th>b</th><th>c</th></tr></thead>
+<tbody>
+<tr><td><b>r2asc1</b></td><td><b>r2asc2</b></td></tr>
+<tr><td><b>r2bsc1</b></td><td><b>r2bsc2</b></td></tr>
+</tbody>
+</table></td></tr>
+</tbody>
+</table>


### PR DESCRIPTION
Adding a parameter `convert` in `__html__()` function in class `Table`, to choose to escape HTML content or not ? By default it is set to `True` as before, it means the content is escaped. But if we added HTML tag in `<td>{}</td>`, it would be better to set `convert=False` to keep the content meaningful.