### PR TITLE
Refactor handling of HTML

### DIFF
--- a/README
+++ b/README
@@ -64,6 +64,9 @@ Extra things:
 -  contain dicts or objects - there's nothing saying it can't contain
    some of each
 
+-  Adding border to your table by just setting attribute ``border=True``
+   while creating a table.
+
 -  There are also LinkCol and ButtonCol that allow links and buttons,
    which is where the Flask-specific-ness comes in.
 
@@ -95,6 +98,9 @@ Included Col Types
 
 -  ```ButtonCol`` <#more-about-buttoncol>`__ (subclass of LinkCol)
    creates a button that posts the the given address.
+
+-  ```NestedTableCol`` <#more-about-nestedtablecol>`__ - allows nesting
+   of tables inside columns
 
 More about ``OptCol``
 ---------------------
@@ -184,6 +190,26 @@ added into the form.]]
 [[Possible future work: make it so you can specify attributes for the
 HTML form or button elements.]]
 
+More about ``NestedTableCol``
+-----------------------------
+
+This column type makes it possible to nest tables in columns. For each
+nested table column you need to define a subclass of Table as you
+normally would when defining a table. The name of that Table sub-class
+is the second argument to NestedTableCol.
+
+Eg:
+
+.. code:: python
+
+    class MySubTable(Table):
+        a = Col('1st nested table col')
+        b = Col('2nd nested table col')
+
+    class MainTable(Table):
+        id = Col('id')
+        objects = NestedTableCol('objects', MySubTable)
+
 Subclassing Col
 ===============
 
@@ -253,15 +279,8 @@ Manipulating ``<tr>``\ s
 (Look in examples/rows.py for a more concrete example)
 
 Suppose you want to change something about the tr element for some or
-all items. You can do this by overriding your table's ``tr_format``
-method. By default, this method returns:
-
-.. code:: python
-
-    '<tr>{}</tr>'
-
-which betrays the fact that it has ``.format()`` called on it, to put in
-the tds. If you override the method, keep that in mind.
+all items. You can do this by overriding your table's ``get_tr_attrs``
+method. By default, this method returns an empty dict.
 
 So, we might want to use something like:
 
@@ -271,11 +290,11 @@ So, we might want to use something like:
         name = Col('Name')
         description = Col('Description')
 
-        def tr_format(self, item):
+        def get_tr_attrs(self, item):
             if item.important():
-                return '<tr class="important">{}</tr>'
+                return {'class': 'important'}
             else:
-                return '<tr>{}</tr>'
+                return {}
 
 which would give all trs for items that returned a true value for the
 ``important()`` method, a class of "important".
@@ -330,6 +349,24 @@ something like
     TableCls = create_table('TableCls')
     for i in range(num):
         TableCls.add_column(str(i), Col(str(i)))
+
+We can also set some extra options to the table class by passing
+``options`` parameter to ``create_table()``:
+
+.. code:: python
+
+    tbl_options = dict(
+        classes=['cls1', 'cls2'],
+        thead_classes=['cls_head1', 'cls_head2'],
+        no_items='Empty')
+    TableCls = create_table(options=tbl_options)
+
+    # equals to
+
+    class TableCls(Table):
+        classes = ['cls1', 'cls2']
+        thead_classes = ['cls_head1', 'cls_head2']
+        no_items = 'Empty'
 
 Sortable Tables
 ===============
@@ -395,3 +432,5 @@ well as objects.
 
 .. |Build Status| image:: https://travis-ci.org/plumdog/flask_table.svg?branch=master
    :target: https://travis-ci.org/plumdog/flask_table
+.. |Coverage Status| image:: https://coveralls.io/repos/plumdog/flask_table/badge.png?branch=master
+   :target: https://coveralls.io/r/plumdog/flask_table?branch=master

--- a/README.md
+++ b/README.md
@@ -292,15 +292,8 @@ Manipulating `<tr>`s
 (Look in examples/rows.py for a more concrete example)
 
 Suppose you want to change something about the tr element for some or
-all items. You can do this by overriding your table's `tr_format`
-method. By default, this method returns:
-
-```python
-'<tr>{}</tr>'
-```
-
-which betrays the fact that it has `.format()` called on it, to put in
-the tds. If you override the method, keep that in mind.
+all items. You can do this by overriding your table's `get_tr_attrs`
+method. By default, this method returns an empty dict.
 
 So, we might want to use something like:
 
@@ -309,11 +302,11 @@ class ItemTable(Table):
     name = Col('Name')
     description = Col('Description')
 
-    def tr_format(self, item):
+    def get_tr_attrs(self, item):
         if item.important():
-            return '<tr class="important">{}</tr>'
+            return {'class': 'important'}
         else:
-            return '<tr>{}</tr>'
+            return {}
 ```
 
 which would give all trs for items that returned a true value for the

--- a/examples/rows.py
+++ b/examples/rows.py
@@ -18,11 +18,11 @@ class ItemTable(Table):
     name = Col('Name')
     description = Col('Description')
 
-    def tr_format(self, item):
+    def get_tr_attrs(self, item):
         if item.important():
-            return '<tr class="important">{}</tr>'
+            return {'class': 'important'}
         else:
-            return '<tr>{}</tr>'
+            return {}
 
 
 def main():

--- a/flask_table/html.py
+++ b/flask_table/html.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from functools import partial
+
+from flask import Markup
+
+
+def element(element, attrs=None, content='',
+            escape_attrs=True, escape_content=True):
+    return '<{element}{formatted_attrs}>{content}</{element}>'.format(
+        element=element,
+        formatted_attrs=_format_attrs(attrs or {}, escape_attrs),
+        content=_format_content(content, escape_content),
+    )
+
+
+def _format_attrs(attrs, escape_attrs=True):
+    out = []
+    for name, value in sorted(attrs.items()):
+        if escape_attrs:
+            name = Markup.escape(name)
+            value = Markup.escape(value)
+        out.append(' {name}="{value}"'.format(name=name, value=value))
+    return ''.join(out)
+
+
+def _format_content(content, escape_content=True):
+    if escape_content:
+        return Markup.escape(content)
+    return content

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -228,13 +228,12 @@ class OverrideTrTest(TableTest):
         class MyTable(Table):
             number = Col('Number')
 
-            def tr_format(self, item):
+            def get_tr_attrs(self, item):
                 if item['number'] % 3 == 1:
-                    return '<tr class="threes-plus-one">{}</tr>'
+                    return {'class': 'threes-plus-one'}
                 elif item['number'] % 3 == 2:
-                    return '<tr class="threes-plus-two">{}</tr>'
-                else:
-                    return '<tr>{}</tr>'
+                    return {'class': 'threes-plus-two'}
+                return {}
 
         self.table_cls = MyTable
 

--- a/tests/html/button_test/test_one.html
+++ b/tests/html/button_test/test_one.html
@@ -9,7 +9,7 @@
     <tr>
       <td>one</td>
       <td>
-	<form method="post" action="/delete/1">
+	<form action="/delete/1" method="post">
 	  <button type="submit">Delete</button>
 	</form>
       </td>


### PR DESCRIPTION
Note that this PR does remove the following methods from the `Table` class:

`tr_format`, `classes_html_attr`, `thead_classes_html_attr`

These are each replaced by similarly named methods that return a dict of attributes for the corresponding html element, rather than a string as the above methods once did.

If you wrote a subclass of `Table` that overrode any of these, your code will now not work.

For example, see the way the `rows.py` example has changed: https://github.com/plumdog/flask_table/pull/44/files#diff-d841d1f270a47f10ea9f3b1148847afb