### PR TITLE
Fix for babel env vars at import in datetime example

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Make sure that one of the following is true:
 - `BABEL_DEFAULT_LOCALE` is set as config on the Flask app to a valid locale
 - a `@babel.localeselector` function is configured
 
+Note that Babel reads the environment variables at import time, so if
+you set these within Python, make sure it happens before you import
+Flask Table. The other two options would be considered "better",
+largely for this reason.
+
 More about `LinkCol`
 --------------------
 

--- a/examples/datetimecol.py
+++ b/examples/datetimecol.py
@@ -1,15 +1,15 @@
 import os
 from datetime import datetime
 
-from flask_table import Table, Col, DatetimeCol
-
 # Run this example with LC_TIME=[other locale] to use a different
 # locale's datetime formatting, eg:
 #
 # LC_TIME=en_US python examples/datetimecol.py
 # or
 # LC_TIME=en_GB python examples/datetimecol.py
-os.environ.setdefault('LC_TIME', 'en_GB')
+os.environ.setdefault('LC_TIME', 'en_GB')  # noqa
+
+from flask_table import Table, Col, DatetimeCol
 
 
 class Item(object):


### PR DESCRIPTION
Babel reads environment variables at import time. Handle that better in the example for the case where the code is being run with no environment variables.