### PR TITLE
Make _single_get more flexible for missing column data

### DIFF
--- a/flask_table/columns.py
+++ b/flask_table/columns.py
@@ -13,7 +13,7 @@ def _single_get(item, key):
     try:
         val = item[key]
     except (KeyError, TypeError):
-        val = getattr(item, key)
+        val = getattr(item, key, None)
 
     # once we have the value, try calling it as a function. If
     # that fails, the just return it.


### PR DESCRIPTION
If one is using a NoSQL store like DynamoDB to populate tables, it's possible that an expected field doesn't exist on a query result. Adding the default value parameter to `getattr()` prevents this from throwing an error. 